### PR TITLE
Fix dep repos for Rawhide, document crontab comments

### DIFF
--- a/delorean-user-data.txt
+++ b/delorean-user-data.txt
@@ -276,11 +276,11 @@ write_files:
     permissions: 0755
 
   - content: |
-        echo "*/5 * * * * fedora-master          /usr/local/bin/run-delorean.sh" >> /etc/crontab
-        echo "*/5 * * * * fedora-rawhide-master  /usr/local/bin/run-delorean.sh" >> /etc/crontab
-        echo "*/5 * * * * centos-master          /usr/local/bin/run-delorean.sh" >> /etc/crontab
-        echo "*/5 * * * * centos-kilo            /usr/local/bin/run-delorean-kilo.sh" >> /etc/crontab
-        echo "*/5 * * * * centos-liberty         /usr/local/bin/run-delorean.sh" >> /etc/crontab
+        echo "#*/5 * * * * fedora-master          /usr/local/bin/run-delorean.sh" >> /etc/crontab
+        echo "#*/5 * * * * fedora-rawhide-master  /usr/local/bin/run-delorean.sh" >> /etc/crontab
+        echo "#*/5 * * * * centos-master          /usr/local/bin/run-delorean.sh" >> /etc/crontab
+        echo "#*/5 * * * * centos-kilo            /usr/local/bin/run-delorean-kilo.sh" >> /etc/crontab
+        echo "#*/5 * * * * centos-liberty         /usr/local/bin/run-delorean.sh" >> /etc/crontab
         echo "7   * * * * rdoinfo                 /usr/local/bin/rdoinfo-update.sh" >> /etc/crontab
         ln -snf /home/fedora-rawhide-master/data/repos /var/www/html/f24
         ln -snf /home/fedora-rawhide-master/data/repos /var/www/html/fedora24
@@ -324,6 +324,7 @@ write_files:
         echo "Remember to patch sh.py on all venvs according to https://github.com/amoffat/sh/pull/237"
         echo "Remember to complete lsyncd configuration"
         echo "Remember to setup SSL support for httpd, if needed"
+        echo "Once the post-setup actions are completed, uncomment the worker entries in /etc/crontab"
     path: /root/post-setup.sh
     permissions: 0744
 
@@ -467,16 +468,10 @@ write_files:
   - content: |
         [delorean-liberty-testing]
         name=delorean-liberty-testing
-        baseurl=https://copr-be.cloud.fedoraproject.org/results/apevec/RDO-Liberty/fedora-22-$basearch/
+        baseurl=https://copr-be.cloud.fedoraproject.org/results/apevec/RDO-Liberty/fedora-rawhide-$basearch/
         enabled=1
         gpgcheck=0
         priority=2
-
-        [openstack-kilo]
-        name=openstack-kilo
-        baseurl=http://repos.fedorapeople.org/repos/openstack/openstack-kilo/f22/
-        enabled=1
-        gpgcheck=0
     path: /home/fedora-rawhide-master/data/repos/delorean-deps.repo
     permissions: 0644
 

--- a/docs/delorean-instance.md
+++ b/docs/delorean-instance.md
@@ -85,4 +85,5 @@ Not everything can be deployed automatically. Currently, there are some steps th
 1. sh.py needs to be patched on all venvs, according to the information provided in https://github.com/amoffat/sh/pull/237
 2. To use https, you will need a properly singed SSL certificate. File `/root/README_SSL.txt` contains the information on which files need to be placed in the file system, and how to run the script that will configure it.
 3. The `lsyncd` daemon configuration file, `/etc/lsyncd.conf` needs to be modified to include the IP address of the secondary system. Once that is done, start the `lsyncd` service. Please *do not* enable the service to run on startup. If you do so, during a failover scenario it can overwrite anything in the currently working Delorean instance.
-4. Remove port 22 from the security group, if you want to reduce the number of automated brute-force attacks against `sshd`.
+4. The crontab entries for the workers are commented out by default. Uncomment them to begin processing packages.
+5. Remove port 22 from the security group, if you want to reduce the number of automated brute-force attacks against `sshd`.


### PR DESCRIPTION
- Set new dependency repos for Rawhide to avoid conflicts.
- Crontab entries for workers are commented out by default. Document
  this.
