### PR TITLE
Switch to buildlogs.centos.org

### DIFF
--- a/delorean-user-data.txt
+++ b/delorean-user-data.txt
@@ -444,14 +444,7 @@ write_files:
   - content: |
         [delorean-liberty-testing]
         name=delorean-liberty-testing
-        baseurl=http://cbs.centos.org/repos/cloud7-openstack-liberty-testing/$basearch/os/
-        enabled=1
-        gpgcheck=0
-        priority=2
-
-        [delorean-common-testing]
-        name=delorean-common-testing
-        baseurl=http://cbs.centos.org/repos/cloud7-openstack-common-testing/$basearch/os/
+        baseurl=http://buildlogs.centos.org/centos/7/cloud/$basearch/openstack-liberty/
         enabled=1
         gpgcheck=0
         priority=2
@@ -496,14 +489,7 @@ write_files:
   - content: |
         [delorean-liberty-testing]
         name=delorean-liberty-testing
-        baseurl=http://cbs.centos.org/repos/cloud7-openstack-liberty-testing/$basearch/os/
-        enabled=1
-        gpgcheck=0
-        priority=2
-
-        [delorean-common-testing]
-        name=delorean-common-testing
-        baseurl=http://cbs.centos.org/repos/cloud7-openstack-common-testing/$basearch/os/
+        baseurl=http://buildlogs.centos.org/centos/7/cloud/$basearch/openstack-liberty/
         enabled=1
         gpgcheck=0
         priority=2


### PR DESCRIPTION
There's now automatic sync from liberty|common-testing CBS tags
to http://buildlogs.centos.org/centos/7/cloud/x86_64/openstack-liberty/
This should be more reliable and with better network connectivity
than cbs.centos.org/repos/

Fixes redhat-openstack#11
